### PR TITLE
Trimming spaces at beginning and end of message

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,6 +23,7 @@
             <div class="input-container">
                 <textarea  id="message" placeholder="Literally anything you want"></textarea>
                 <p id="message-error"> </p>
+                <p id="charCount">0</p> 
             </div>
             <button id="sendBtn" onclick="sendMessage()">Send</button>
         </div>

--- a/index.html
+++ b/index.html
@@ -23,7 +23,6 @@
             <div class="input-container">
                 <textarea  id="message" placeholder="Literally anything you want"></textarea>
                 <p id="message-error"> </p>
-                <p id="charCount">0</p> 
             </div>
             <button id="sendBtn" onclick="sendMessage()">Send</button>
         </div>

--- a/script.js
+++ b/script.js
@@ -45,7 +45,7 @@ function sendMessage(){
     const isMessageValid = messageValidator();
 
     if (isInputValid && isMessageValid) {
-        let message = style + messageInput.value.trim() + style;
+        let message = style + messageInput.value.replace(/^\s+|\s+$/g, '') + style; // trim beginning/end spaces
         let api = `https://api.whatsapp.com/send/?phone=${number.value}&text=${message}`
     
         let a = document.createElement('a');

--- a/script.js
+++ b/script.js
@@ -4,7 +4,6 @@ let sendBtn= document.getElementById('sendBtn');
 let input_error =document.getElementById("input-error");
 let message_error =document.getElementById("message-error");
 let style = '';
-let char_count = document.getElementById("char-count");
 
 
 
@@ -46,7 +45,7 @@ function sendMessage(){
     const isMessageValid = messageValidator();
 
     if (isInputValid && isMessageValid) {
-        let message = style+ messageInput.value + style;
+        let message = style + messageInput.value.trim() + style;
         let api = `https://api.whatsapp.com/send/?phone=${number.value}&text=${message}`
     
         let a = document.createElement('a');
@@ -56,11 +55,3 @@ function sendMessage(){
 
     }
 }
-
-// updates message length 
-function updateCharCount() {
-    char_count.innerHTML = messageInput.value.length;
-}
-
-// event listener that updates char count in real time
-messageInput.addEventListener('input', updateCharCount);

--- a/script.js
+++ b/script.js
@@ -43,9 +43,10 @@ function messageValidator(){
 function sendMessage(){
     const isInputValid = inputValidator();
     const isMessageValid = messageValidator();
+    let trimmed = messageInput.value.replace(/^\s+|\s+$/g, '');
 
-    if (isInputValid && isMessageValid) {
-        let message = style + messageInput.value.replace(/^\s+|\s+$/g, '') + style; // trim beginning/end spaces
+    if (isInputValid && isMessageValid && trimmed.length > 0) {
+        let message = style + trimmed + style; // trim beginning or end spaces
         let api = `https://api.whatsapp.com/send/?phone=${number.value}&text=${message}`
     
         let a = document.createElement('a');
@@ -53,5 +54,8 @@ function sendMessage(){
         a.setAttribute('target',"_blank"); //for opening in a new tab  
         a.click()
 
+    } else {
+        message_error.style.display = 'block';
+        message_error.innerHTML = "message cannot be only spaces"
     }
 }

--- a/script.js
+++ b/script.js
@@ -4,7 +4,7 @@ let sendBtn= document.getElementById('sendBtn');
 let input_error =document.getElementById("input-error");
 let message_error =document.getElementById("message-error");
 let style = '';
-let charCount = document.getElementById("charCount");
+let char_count = document.getElementById("char-count");
 
 
 
@@ -59,7 +59,7 @@ function sendMessage(){
 
 // updates message length 
 function updateCharCount() {
-    charCount.innerHTML = messageInput.value.length;
+    char_count.innerHTML = messageInput.value.length;
 }
 
 // event listener that updates char count in real time

--- a/script.js
+++ b/script.js
@@ -4,13 +4,13 @@ let sendBtn= document.getElementById('sendBtn');
 let input_error =document.getElementById("input-error");
 let message_error =document.getElementById("message-error");
 let style = '';
+let charCount = document.getElementById("charCount");
 
 
 
 function setStyle(e){
     style = e.value;
 }
-
 
 function inputValidator(){
     if(number.value.length!=10){
@@ -25,6 +25,7 @@ function inputValidator(){
         
     }
 }
+
 function messageValidator(){
 
     if(messageInput.value.length<=0){
@@ -40,7 +41,6 @@ function messageValidator(){
     }
 }
 
-
 function sendMessage(){
     const isInputValid = inputValidator();
     const isMessageValid = messageValidator();
@@ -55,5 +55,12 @@ function sendMessage(){
         a.click()
 
     }
-
 }
+
+// updates message length 
+function updateCharCount() {
+    charCount.innerHTML = messageInput.value.length;
+}
+
+// event listener that updates char count in real time
+messageInput.addEventListener('input', updateCharCount);

--- a/style.css
+++ b/style.css
@@ -114,6 +114,8 @@ button:hover{
     
 }
 
-#charCount {
-    text-align: right;
+#char-count {
+    float: right;
+    font-family: Arial, Helvetica, sans-serif;
+    font-size: small;
 }

--- a/style.css
+++ b/style.css
@@ -4,10 +4,12 @@
     box-sizing: border-box;
     font-family: 'poppins',sans-serif;
 }
+
 :root{
     --font-size:17px;
     --border-radius:6px;
 }
+
 body{
     display: flex;
     justify-content: center;
@@ -16,6 +18,7 @@ body{
     width: 100vw;
     background: linear-gradient(142deg,#222,#a55c1b);
 }
+
 .container{
     display: flex;
     flex-direction: column;
@@ -58,6 +61,7 @@ input::placeholder{
 input{
     font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
 }
+
 textarea{
     width: 100%;
     height: 22vh;
@@ -89,6 +93,7 @@ button:hover{
     background: rgba(0, 0, 0, 0.7);
     box-shadow: 2px 2px  0px  rgba(0, 2, 2, 0.6);
 }
+
 @keyframes shake {
 
     0%{
@@ -107,4 +112,8 @@ button:hover{
         transform: translateX(0px);
     }
     
+}
+
+#charCount {
+    text-align: right;
 }

--- a/style.css
+++ b/style.css
@@ -113,9 +113,3 @@ button:hover{
     }
     
 }
-
-#char-count {
-    float: right;
-    font-family: Arial, Helvetica, sans-serif;
-    font-size: small;
-}


### PR DESCRIPTION
Hello! I added a regex that trims the message input so that spaces do not appear at the beginning or end of messages, as suggested in #3. In `script,js`...

```
let trimmed = messageInput.value.replace(/^\s+|\s+$/g, '');
```

Then, to prevent users from sending messages that are entirely spaces (and thus sending an empty message, which surely WhatsApp wouldn't appreciate), I added a check that ensures messages are at least length 1. If not, an error message appears.

```
if (isInputValid && isMessageValid && trimmed.length > 0) {
        let message = style + trimmed + style; 
     
        \\ code for sending that was already present
        
else {
        message_error.style.display = 'block';
        message_error.innerHTML = "message cannot be only spaces"
}
```
    
Let me know what you think. Full disclosure -- I have contributed to this project as part of a final project on a Git course at a university. 